### PR TITLE
Calendar View: Re-arrange calendar view event lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In use on our wall and main menu:
 
 Calendar View And Calendar event creation:
 
-<img src="https://user-images.githubusercontent.com/16851195/218835231-e895b2b2-f7b0-485e-b122-216facbd9688.png" width="whatever" height="300">   <img src="https://user-images.githubusercontent.com/16851195/218835245-13dad67c-8405-44d2-b17c-57658f3496a2.png" width="whatever" height="300">
+<img src="https://user-images.githubusercontent.com/16851195/221368552-9dde5367-a399-4d16-acb6-c1e929427c2d.png" width="whatever" height="300">   <img src="https://user-images.githubusercontent.com/16851195/218835245-13dad67c-8405-44d2-b17c-57658f3496a2.png" width="whatever" height="300">
 
 Todo View:
 

--- a/lib/src/features/calendar/data/calendar_service.dart
+++ b/lib/src/features/calendar/data/calendar_service.dart
@@ -3,13 +3,11 @@ import 'package:home_cloud/src/features/calendar/models/calendar_event_model.dar
 
 class CalendarService {
   final FirebaseFirestore _database = FirebaseFirestore.instance;
-  static const String collectionPath = "calendar-events";
+  static const String collectionPath = "calendar-events-test";
 
   Future<List<CalendarEventModel>> fetchData() async {
-    QuerySnapshot<Map<String, dynamic>> snapshot = await _database
-        .collection(collectionPath)
-        .orderBy('eventDate', descending: false)
-        .get();
+    QuerySnapshot<Map<String, dynamic>> snapshot =
+        await _database.collection(collectionPath).get();
     return snapshot.docs
         .map((documentSnapshot) =>
             CalendarEventModel.fromDocument(documentSnapshot))

--- a/lib/src/features/calendar/view/calendar_grid/calendar_builder_helper.dart
+++ b/lib/src/features/calendar/view/calendar_grid/calendar_builder_helper.dart
@@ -56,11 +56,11 @@ class CalendarBuilderHelper {
         eventColor: list[index].eventColor as Color?,
       ));
       //Break loop if more than 2 items to not overflow calendar date
-      if (index >= 1) break;
+      if (index >= 3) break;
     }
-    if (list.length > 2) {
+    if (list.length > 4) {
       widgets.add(CalendarEvent(
-        eventTitle: CalendarStrings.getMoreEventString(list.length - 2),
+        eventTitle: CalendarStrings.getMoreEventString(list.length - 4),
       ));
     }
     return widgets;

--- a/lib/src/features/calendar/view/calendar_grid/calendar_event.dart
+++ b/lib/src/features/calendar/view/calendar_grid/calendar_event.dart
@@ -22,7 +22,7 @@ class CalendarEvent extends StatelessWidget {
         border: Border.all(color: Colors.black54),
       ),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 3.0),
+        padding: const EdgeInsets.symmetric(horizontal: 3.0, vertical: 2.0),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [

--- a/lib/src/features/calendar/view/calendar_view.dart
+++ b/lib/src/features/calendar/view/calendar_view.dart
@@ -65,26 +65,13 @@ class _CalendarViewState extends State<CalendarView> {
       children: [
         Expanded(
           flex: 2,
-          child: Column(
-            children: [
-              Expanded(
-                flex: 2,
-                child: Padding(
-                  padding: const EdgeInsets.all(4.0),
-                  child: _tableCalendar(),
-                ),
-              ),
-              Expanded(
-                child: _todaySelectedEventsLists(),
-              ),
-            ],
+          child: Padding(
+            padding: const EdgeInsets.all(4.0),
+            child: _tableCalendar(),
           ),
         ),
         Expanded(
-          child: CalendarEventList(
-            title: CalendarStrings.allCalendarEvents,
-            eventsList: allEvents,
-          ),
+          child: _todaySelectedEventsLists(),
         ),
       ],
     );
@@ -115,7 +102,7 @@ class _CalendarViewState extends State<CalendarView> {
         eventLoader: (date) => _getAllEventsByDate(allEvents, date),
       );
 
-  Widget _todaySelectedEventsLists() => Row(
+  Widget _todaySelectedEventsLists() => Column(
         children: [
           Expanded(
             child: CalendarEventList(


### PR DESCRIPTION
Removes all events list and moves today/selected lists right side of view. Resize calendar and add more events per date and a bit bigger